### PR TITLE
feat: support '*' wildcard on department for subscriptions

### DIFF
--- a/api/src/events/operations.ts
+++ b/api/src/events/operations.ts
@@ -33,11 +33,19 @@ export const getSubscriptionsFilter = (event: Event): Filter<Subscription> => {
     subscriptionsFilter['sender.id'] = event.sender.id
     if (event.sender.role) subscriptionsFilter['sender.role'] = event.sender.role
     if (event.sender.department) {
+      // a departmental event also matches subscriptions using the '*' wildcard (any department)
       if (event.sender.department !== '*') {
-        subscriptionsFilter['sender.department'] = event.sender.department
+        subscriptionsFilter.$or = [
+          { 'sender.department': event.sender.department },
+          { 'sender.department': '*' }
+        ]
       }
     } else {
-      subscriptionsFilter['sender.department'] = { $exists: false }
+      // a root event matches subscriptions without department, or using the '*' wildcard
+      subscriptionsFilter.$or = [
+        { 'sender.department': { $exists: false } },
+        { 'sender.department': '*' }
+      ]
     }
   } else {
     subscriptionsFilter.sender = { $exists: false }

--- a/tests/events.unit.spec.ts
+++ b/tests/events.unit.spec.ts
@@ -62,7 +62,12 @@ test.describe('getSubscriptionsFilter', () => {
     const filter = getSubscriptionsFilter(event)
     expect(filter['sender.type']).toBe('organization')
     expect(filter['sender.id']).toBe('org1')
-    expect(filter['sender.department']).toEqual({ $exists: false })
+    // a root event matches subscriptions without department, or using the '*' wildcard
+    expect(filter.$or).toEqual([
+      { 'sender.department': { $exists: false } },
+      { 'sender.department': '*' }
+    ])
+    expect(filter['sender.department']).toBeUndefined()
   })
 
   test('filters by sender with department', () => {
@@ -71,7 +76,12 @@ test.describe('getSubscriptionsFilter', () => {
       sender: { type: 'organization', id: 'org1', department: 'dep1' }
     }
     const filter = getSubscriptionsFilter(event)
-    expect(filter['sender.department']).toBe('dep1')
+    // a departmental event also matches subscriptions using the '*' wildcard (any department)
+    expect(filter.$or).toEqual([
+      { 'sender.department': 'dep1' },
+      { 'sender.department': '*' }
+    ])
+    expect(filter['sender.department']).toBeUndefined()
   })
 
   test('wildcard department does not filter', () => {

--- a/tests/subscriptions.api.spec.ts
+++ b/tests/subscriptions.api.spec.ts
@@ -140,6 +140,33 @@ test.describe('subscriptions', () => {
     expect(res.data.count).toBe(1)
   })
 
+  test('should send any-department subscription notifications for root and departmental events', async () => {
+    // a root member subscribes to every department of the org using the '*' wildcard
+    const res = await admin1.post('/api/subscriptions', {
+      topic: { key: 'topic1' },
+      sender: { type: 'organization', id: 'test1', department: '*', name: 'Test Organization 1' }
+    })
+    expect(res.data.visibility).toBe('private')
+
+    // a root event (no department) must reach the wildcard subscription
+    await axPush.post('/api/events', [{
+      date: new Date().toISOString(),
+      topic: { key: 'topic1' },
+      title: 'a root notification',
+      sender: { type: 'organization', id: 'test1', name: 'Test Organization 1' }
+    }])
+    // a departmental event must also reach the wildcard subscription
+    await axPush.post('/api/events', [{
+      date: new Date().toISOString(),
+      topic: { key: 'topic1' },
+      title: 'a departmental notification',
+      sender: { type: 'organization', id: 'test1', department: 'dep1', name: 'Test Organization 1' }
+    }])
+
+    const notifs = await admin1.get('/api/notifications')
+    expect(notifs.data.count).toBe(2)
+  })
+
   test('should send a private department notification to member of right department in sender organization', async () => {
     let res = await user1.post('/api/subscriptions', {
       topic: { key: 'topic1' },

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
     <link href="{SITE_PATH}/simple-directory/api/sites/_theme.css" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
Support a `*` wildcard on a subscription's `sender.department`, so an "any-department" subscription receives both root (no-department) and departmental events for the organization.

**Why:** let a root member subscribe once to a topic across every department of an org, instead of subscribing per department.

**Also in this branch:** aligns the Playwright config with the data-fair/portals template — `test-unit`/`test-api`/`test-e2e` scripts, an `e2e-warmup` project that pre-compiles heavy Vite dev routes before the e2e specs, and explicit timeouts. `ui/index.html` also gains `<meta name="robots" content="noindex">` to match the portals template.

**Regression risks:**
- `getSubscriptionsFilter` now builds a `$or` on `sender.department` instead of a scalar equality; behavior intentionally broadens so `*` subscriptions also match. `$or` is set in only one place in the function, so there's no clobbering.
- CI `retries` goes from `0` to `1`, which can mask newly-flaky tests.
- `noindex` on the UI stops search engines indexing it.
