### PR TITLE
feat(lib-vuetify): add realtime websocket to notification queue

### DIFF
--- a/lib-vuetify/DfNotificationQueue.vue
+++ b/lib-vuetify/DfNotificationQueue.vue
@@ -2,18 +2,18 @@
   <!-- Eager to prevent ARIA errors-->
   <v-menu
     :close-on-content-click="false"
+    style="z-index: 2600; /* Higher than agent-chat's 2500 */"
     max-height="400"
     max-width="500"
     width="100%"
     eager
-    style="z-index: 2600; /* Higher than agent-chat's 2500 */"
+    @update:model-value="(open) => refresh(open ? 10 : 0)"
   >
     <template #activator="{ props }">
       <v-btn
         v-bind="props"
         :title="t('openNotificationList')"
         stacked
-        @click="refresh()"
       >
         <v-badge
           :model-value="!!countNew"
@@ -25,14 +25,17 @@
       </v-btn>
     </template>
 
-    <v-list density="compact">
+    <v-list
+      density="compact"
+      class="py-0"
+    >
       <v-list-item v-if="!session.state.user">
         {{ t('loginRequired.part1') }} <a
           :href="session.loginUrl()"
           class="simple-link"
         >{{ t('loginRequired.part2') }}</a> {{ t('loginRequired.part3') }}
       </v-list-item>
-      <v-list-item v-else-if="!notifications || !notifications.length">
+      <v-list-item v-else-if="!notifications.length">
         {{ t('noNotifications') }}
       </v-list-item>
       <v-list-item
@@ -40,13 +43,14 @@
         v-else
         :key="notif._id"
         :href="notif.url"
-        :title="notif.title"
-        :subtitle="dayjs(notif.date).format('lll')"
         :value="notif._id"
         :active="notif.new"
-        active-class="text-pink"
+        active-class="text-warning"
         lines="three"
       >
+        <template #title>
+          <span :title="notif.title">{{ notif.title }}</span>
+        </template>
         <template #subtitle>
           {{ dayjs(notif.date).format('lll') }}
           <div v-if="notif.body">{{ notif.body }}</div>
@@ -64,17 +68,17 @@
 </template>
 
 <script setup lang="ts">
+import type { Emitter } from '@data-fair/lib-common-types/event/index.js'
 import { ref, onMounted } from 'vue'
 import { ofetch } from 'ofetch'
 import OwnerAvatar from '@data-fair/lib-vuetify/owner-avatar.vue'
 import useSession from '@data-fair/lib-vue/session.js'
 import useLocaleDayjs from '@data-fair/lib-vue/locale-dayjs.js'
+import useWS from '@data-fair/lib-vue/ws.js'
 import { useI18n } from 'vue-i18n'
 import { mdiBell } from '@mdi/js'
 
-const props = defineProps<{
-  eventsUrl: string
-}>()
+const { eventsUrl } = defineProps<{ eventsUrl: string }>()
 
 const session = useSession()
 const { dayjs } = useLocaleDayjs()
@@ -87,11 +91,7 @@ type NotificationItem = {
   body?: string
   url?: string
   new?: boolean
-  sender?: {
-    type: 'user' | 'organization'
-    id: string
-    name?: string
-  }
+  sender?: Emitter
 }
 
 type NotificationsRes = {
@@ -103,15 +103,23 @@ type NotificationsRes = {
 const notifications = ref<NotificationItem[]>([])
 const countNew = ref(0)
 
-async function refresh () {
+async function refresh (size = 10) {
   if (!session.state.user) return
-  const res = await ofetch<NotificationsRes>(`${props.eventsUrl}/notifications`, { query: { size: 10 } })
-  notifications.value = res.results
+  const res = await ofetch<NotificationsRes>(`${eventsUrl}/api/notifications`, { query: { size } })
+  if (size > 0) notifications.value = res.results
   countNew.value = res.countNew
 }
 
 onMounted(() => {
   refresh()
+  const userId = session.state.user?.id
+  const ws = useWS(eventsUrl + '/api/')
+  if (ws && userId) {
+    ws.subscribe<NotificationItem>(`user:${userId}:notifications`, (notif) => {
+      notifications.value = [{ ...notif, new: true }, ...notifications.value]
+      countNew.value += 1
+    })
+  }
 })
 </script>
 

--- a/lib-vuetify/package.json
+++ b/lib-vuetify/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "vue": "^3.5.0",
     "vuetify": "^4.0.0",
+    "@data-fair/lib-common-types": "^1.20.0",
     "@data-fair/lib-vuetify": "^2.0.0",
     "@data-fair/lib-vue": "^1.26.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "ofetch": "^1.4.0"
       },
       "peerDependencies": {
+        "@data-fair/lib-common-types": "^1.20.0",
         "@data-fair/lib-vue": "^1.26.0",
         "@data-fair/lib-vuetify": "^2.0.0",
         "vue": "^3.5.0",

--- a/tests/dev-notification-queue.e2e.spec.ts
+++ b/tests/dev-notification-queue.e2e.spec.ts
@@ -36,4 +36,30 @@ test.describe('DfNotificationQueue on dev page', () => {
     await page.getByRole('button', { name: 'Open notification list' }).click()
     await expect(page.getByText('Dev page notification title')).toBeVisible()
   })
+
+  test('shows notification in real time via websocket without reload', async ({ page, goToWithAuth }) => {
+    // create a subscription for test-user1
+    const user1 = await axiosAuth('test-user1')
+    await user1.post('/api/subscriptions', {
+      topic: { key: 'topic1' },
+      sender: { type: 'user', id: 'test-user1', name: 'User 1' },
+      outputs: ['devices']
+    })
+
+    // open the dev page and the (empty) notification list FIRST, page stays open
+    await goToWithAuth('/events/dev', 'test-user1')
+    await page.getByRole('button', { name: 'Open notification list' }).click()
+    await expect(page.getByText('You have not received any notifications yet.')).toBeVisible()
+
+    // push an event while the page is still open
+    await axPush.post('/api/events', [{
+      date: new Date().toISOString(),
+      topic: { key: 'topic1' },
+      title: 'Realtime notification title',
+      sender: { type: 'user', id: 'test-user1', name: 'User 1' }
+    }])
+
+    // it must appear without any reload or manual refresh (websocket push)
+    await expect(page.getByText('Realtime notification title')).toBeVisible({ timeout: 10000 })
+  })
 })

--- a/ui/src/context.ts
+++ b/ui/src/context.ts
@@ -5,4 +5,5 @@ export const $uiConfig = (window as any).__UI_CONFIG as UiConfig
 export const $sitePath = (window as any).__SITE_PATH as string
 export const $cspNonce = (window as any).__CSP_NONCE as string
 export const $apiPath = $sitePath + '/events/api'
+export const $eventsUrl = $sitePath + '/events'
 export const $fetch = ofetch.create({ baseURL: $apiPath })

--- a/ui/src/pages/dev.vue
+++ b/ui/src/pages/dev.vue
@@ -2,7 +2,7 @@
   <div>
     <v-app-bar density="comfortable">
       <v-spacer />
-      <df-notification-queue :events-url="$apiPath" />
+      <df-notification-queue :events-url="$eventsUrl" />
       <personal-menu dark-mode-switch />
     </v-app-bar>
 
@@ -25,7 +25,7 @@
 <script setup lang="ts">
 import personalMenu from '@data-fair/lib-vuetify/personal-menu.vue'
 import { DfNotificationQueue } from '@data-fair/lib-vuetify-events'
-import { $apiPath } from '../context.ts'
+import { $eventsUrl } from '../context.ts'
 
 const session = useSession()
 


### PR DESCRIPTION
Consolidate the realtime notification queue (proven in data-fair's local fork) into the shared `@data-fair/lib-vuetify-events` lib so data-fair and portals share one source.

- `DfNotificationQueue.vue`: subscribe to `user:<id>:notifications` over WebSocket (`@data-fair/lib-vue/ws`) and prepend pushed notifications live; `refresh(size)` reloads the list on menu open and only refreshes the unread count on close.
- `eventsUrl` prop now means the events service root: REST hits `${eventsUrl}/api/notifications` and the WS connects to `${eventsUrl}/api/` (same base as REST, so it reaches the API/ws-server even in split UI/API topologies).
- `sender` typed as `Emitter` (adds `@data-fair/lib-common-types` peer dependency).
- `dev.vue` passes the new `$eventsUrl` (service root) instead of `$apiPath`.
- New e2e test asserts a pushed event appears in the open bell without reload.

**Why:** the realtime version only lived in data-fair's local fork (which overrode this lib via a vite alias); portals carried a separate static fork. This makes the lib the single canonical source.

**Regression risks:**
- Breaking prop-contract change: `eventsUrl` must now be the events service root (not the `/api` base), and consumers must route `/events/api/` to the events service. Verified end-to-end in data-fair and portals — realtime push works through nginx with no extra config.
- New `@data-fair/lib-common-types` peer dependency; consumers must provide it.
- No version bump in this PR; the `0.3.0` release is a separate follow-up commit on main.
